### PR TITLE
Update backend CORS with cache-control

### DIFF
--- a/backend/src/main/java/com/fistein/config/CacheControlHeaderFilter.java
+++ b/backend/src/main/java/com/fistein/config/CacheControlHeaderFilter.java
@@ -1,0 +1,20 @@
+package com.fistein.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class CacheControlHeaderFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        response.setHeader("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0");
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/fistein/config/SecurityConfig.java
+++ b/backend/src/main/java/com/fistein/config/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.beans.factory.annotation.Autowired;
 
 @Configuration
 @EnableWebSecurity
@@ -30,6 +31,9 @@ public class SecurityConfig {
     private final PasswordEncoder passwordEncoder;
     // CorsConfigurationSource, CorsConfig sınıfında tanımlanan bean'i kullanır
     private final CorsConfigurationSource corsConfigurationSource;
+    // CacheControlHeaderFilter, her response'a Cache-Control header'ı ekler.
+    @Autowired
+    private CacheControlHeaderFilter cacheControlHeaderFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -56,7 +60,9 @@ public class SecurityConfig {
                 .authenticationProvider(authenticationProvider())
                 // JWT kimlik doğrulama filtresini UsernamePasswordAuthenticationFilter'dan önce ekler.
                 // Bu, her istekte JWT token'ını kontrol etmeyi sağlar.
-                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
+                // Cache-Control header filtresini UsernamePasswordAuthenticationFilter'dan önce ekler.
+                .addFilterBefore(cacheControlHeaderFilter, UsernamePasswordAuthenticationFilter.class);
 
         // Oluşturulan SecurityFilterChain'i döndürür.
         return http.build();


### PR DESCRIPTION
Add `Cache-Control` header to all backend responses to ensure proper caching behavior for CORS requests.