### PR TITLE
Externalize configuration, add local profile and application-local.yml

### DIFF
--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,0 +1,15 @@
+spring:
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/fistein_db}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+    driver-class-name: org.postgresql.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: ${JPA_DDL_AUTO:update}
+    show-sql: ${JPA_SHOW_SQL:true}
+    properties:
+      hibernate:
+        format_sql: true
+    database-platform: org.hibernate.dialect.PostgreSQLDialect

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,29 +1,20 @@
 spring:
-  datasource:
-    url: jdbc:postgresql://localhost:5432/fistein_db
-    username: postgres
-    password: Ysn2025!
-    driver-class-name: org.postgresql.Driver
+  application:
+    name: fistein-backend
 
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-    show-sql: true
-    properties:
-      hibernate:
-        format_sql: true
-    database-platform: org.hibernate.dialect.PostgreSQLDialect
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local}
 
   mvc:
     problemdetails:
       enabled: true
 
 server:
-  port: 8080
+  port: ${SERVER_PORT:8080}
 
 jwt:
-  secret: dGhpc0lzQUdvb2RTZWNyZXRLZXlGb3JKV1RUaGF0SXNBVE1lYXN0MjU2Qml0c0xvbmdGb3JTZWN1cml0eVB1cnBvc2Vz
-  expiration: 86400
+  secret: ${JWT_SECRET:change-this-in-env}
+  expiration: ${JWT_EXPIRATION:86400}
 
 google:
   oauth:


### PR DESCRIPTION
### Motivation
- Remove hard-coded credentials and environment-specific settings from the default config and enable local profile-based overrides.
- Provide a dedicated `application-local.yml` to hold development datasource and JPA settings with sensible environment-variable defaults.

### Description
- Add `backend/src/main/resources/application-local.yml` containing datasource and JPA configuration that reads values from environment variables with defaults. 
- Update `backend/src/main/resources/application.yml` to externalize sensitive and environment-specific values by introducing environment-variable placeholders for `spring.profiles.active`, `server.port`, and `jwt` values and to set `spring.application.name`.
- Move Hibernate `ddl-auto`, `show-sql`, and formatting settings out of the main YAML and rely on the local profile file for development-specific behavior.

### Testing
- Ran the backend test suite with `./mvnw test`, and all tests completed successfully.
- Built the project with `./mvnw package` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc70bdee48832197c99196fda2f144)